### PR TITLE
bump example compatibility to Spark 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,20 +13,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-
 	<dependencies>
-		<dependency>
-			<groupId>com.databricks</groupId>
-			<artifactId>spark-csv_2.10</artifactId>
-			<version>1.3.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
 		<!-- Inherited from org.jpmml:jpmml-sparkml:1.0.4 -->
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -37,13 +24,13 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-core_2.10</artifactId>
-			<version>[1.6.0, 1.6.2]</version>
+			<version>2.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-mllib_2.10</artifactId>
-			<version>[1.6.0, 1.6.2]</version>
+			<version>2.0.0</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -55,14 +42,14 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql_2.10</artifactId>
-			<version>[1.6.0, 1.6.2]</version>
+			<version>2.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jpmml</groupId>
 			<artifactId>jpmml-sparkml</artifactId>
-			<version>1.0.5</version>
+			<version>1.1.3</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/jpmml/sparkml/bootstrap/Main.java
+++ b/src/main/java/org/jpmml/sparkml/bootstrap/Main.java
@@ -103,6 +103,7 @@ public class Main {
                 .format("csv")
                 .option("header", "true")
                 .option("nullValue", "")
+                .option("inferSchema", "true")
                 .csv(this.csvInput.getAbsolutePath())
                 ;
 


### PR DESCRIPTION
Bumped the version to Spark 2.0.0 

There are some changes in terms of compatibility with older spark versions:
- csv is included in spark by default (no need to install `spark-csv`)
- API now uses sparkSession to read a csv.
- No dataframes, now they are `DataSet[Row]`

I have basically no experience with Java, so im not sure if this is how you would build the `pom.xml` file. Please change this PR as you see fit :)
